### PR TITLE
feat: adicionar páginas de Autores e Política Editorial e atualizar SEO, sitemap, feed e integração Supabase

### DIFF
--- a/ads.txt
+++ b/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-0000000000000000, DIRECT, f08c47fec0942fa0

--- a/autores.html
+++ b/autores.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Autores | Jornal Agora</title>
+  <meta name="description" content="Conheça os autores do Jornal Agora, suas áreas de cobertura e experiência editorial." />
+  <meta name="robots" content="index,follow" />
+  <link rel="canonical" href="https://www.jornalagora.com.br/autores.html" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="container topbar-content">
+      <a class="logo" href="index.html">Jornal <span>Agora</span></a>
+      <nav class="top-nav">
+        <a href="index.html">Início</a>
+        <a href="sobre.html">Sobre</a>
+        <a href="contato.html">Contato</a>
+        <a href="politica-de-privacidade.html">Privacidade</a>
+        <a href="termos-de-uso.html">Termos</a>
+        <a href="autores.html">Autores</a>
+        <a href="politica-editorial.html">Editorial</a>
+      </nav>
+      <button id="themeToggle" class="theme-toggle" aria-label="Alternar tema">🌙</button>
+    </div>
+  </header>
+
+  <main class="container page">
+    <section class="card content article-body">
+      <h1>Nossos Autores</h1>
+      <p>As reportagens do Jornal Agora são produzidas por profissionais com experiência em jornalismo de dados, política pública, economia e saúde.</p>
+
+      <h2>Redação Jornal Agora</h2>
+      <p><strong>Foco:</strong> Políticas públicas, tecnologia cívica e inovação social.</p>
+      <p><strong>Bio:</strong> Equipe multidisciplinar responsável pela cobertura diária e apuração com fontes oficiais e especialistas.</p>
+
+      <h2>Redação Economia</h2>
+      <p><strong>Foco:</strong> Mercado de crédito, emprego, empreendedorismo e análise de impacto econômico.</p>
+      <p><strong>Bio:</strong> Jornalistas com experiência em negócios e finanças públicas, com linguagem acessível para o público geral.</p>
+
+      <h2>Redação Saúde</h2>
+      <p><strong>Foco:</strong> Saúde pública, prevenção, campanhas nacionais e dados epidemiológicos.</p>
+      <p><strong>Bio:</strong> Profissionais especializados em cobertura de políticas de saúde e divulgação científica.</p>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-links">
+        <a href="sobre.html">Sobre</a>
+        <a href="contato.html">Contato</a>
+        <a href="politica-de-privacidade.html">Política de Privacidade</a>
+        <a href="termos-de-uso.html">Termos de Uso</a>
+        <a href="autores.html">Autores</a>
+        <a href="politica-editorial.html">Política Editorial</a>
+      </div>
+      <p>© 2026 Jornal Agora.</p>
+    </div>
+  </footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/contato.html
+++ b/contato.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Contato | Jornal Agora</title>
+  <meta name="description" content="Canal de contato editorial e comercial do Jornal Agora." />
+  <meta name="robots" content="index,follow" />
+  <link rel="canonical" href="https://www.jornalagora.com.br/contato.html" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="container topbar-content">
+      <a class="logo" href="index.html">Jornal <span>Agora</span></a>
+      <nav class="top-nav">
+        <a href="index.html">Início</a><a href="sobre.html">Sobre</a><a href="contato.html">Contato</a><a href="politica-de-privacidade.html">Privacidade</a><a href="termos-de-uso.html">Termos</a>
+        <a href="autores.html">Autores</a>
+        <a href="politica-editorial.html">Editorial</a>
+      </nav>
+      <button id="themeToggle" class="theme-toggle" aria-label="Alternar tema">🌙</button>
+    </div>
+  </header>
+  <main class="container page">
+    <section class="card content article-body">
+      <h1>Contato</h1>
+      <p>Fale com a redação: <a href="mailto:redacao@jornalagora.com.br">redacao@jornalagora.com.br</a></p>
+      <p>Contato comercial: <a href="mailto:comercial@jornalagora.com.br">comercial@jornalagora.com.br</a></p>
+      <p>Prazo de resposta médio: até 2 dias úteis.</p>
+      <p>Também recebemos sugestões de pauta e pedidos de correção por e-mail.</p>
+    </section>
+  </main>
+  <footer class="footer"><div class="container"><div class="footer-links"><a href="sobre.html">Sobre</a><a href="contato.html">Contato</a><a href="politica-de-privacidade.html">Política de Privacidade</a><a href="termos-de-uso.html">Termos de Uso</a>
+        <a href="autores.html">Autores</a>
+        <a href="politica-editorial.html">Política Editorial</a></div><p>© 2026 Jornal Agora.</p></div></footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/feed.xml
+++ b/feed.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Jornal Agora</title>
+    <link>https://www.jornalagora.com.br/</link>
+    <description>Notícias de política, economia, saúde e tecnologia.</description>
+    <language>pt-BR</language>
+    <lastBuildDate>Tue, 10 Feb 2026 00:00:00 GMT</lastBuildDate>
+
+    <item>
+      <title>Governo anuncia plano de infraestrutura digital</title>
+      <link>https://www.jornalagora.com.br/noticia-infraestrutura-digital.html</link>
+      <pubDate>Mon, 09 Feb 2026 11:00:00 GMT</pubDate>
+      <description>Plano federal amplia conectividade para escolas, saúde e pequenos negócios.</description>
+    </item>
+
+    <item>
+      <title>Crédito verde ganha força e acelera projetos sustentáveis</title>
+      <link>https://www.jornalagora.com.br/noticia-credito-verde.html</link>
+      <pubDate>Mon, 09 Feb 2026 12:20:00 GMT</pubDate>
+      <description>Linhas de financiamento com juros reduzidos ampliam investimentos em eficiência energética.</description>
+    </item>
+
+    <item>
+      <title>Mutirões de vacinação são ampliados em mais de 200 cidades</title>
+      <link>https://www.jornalagora.com.br/noticia-vacinacao.html</link>
+      <pubDate>Mon, 09 Feb 2026 13:15:00 GMT</pubDate>
+      <description>Secretarias de saúde reforçam vacinação com horários estendidos e pontos itinerantes.</description>
+    </item>
+  </channel>
+</rss>

--- a/images/credito-verde.svg
+++ b/images/credito-verde.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-label="Ilustração de crédito verde e crescimento sustentável">
+  <defs>
+    <linearGradient id="bg2" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#0a7a37"/>
+      <stop offset="100%" stop-color="#1f4d2a"/>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#bg2)"/>
+  <g fill="#d4ffd8" fill-opacity="0.15">
+    <ellipse cx="280" cy="210" rx="170" ry="100"/>
+    <ellipse cx="1300" cy="710" rx="190" ry="120"/>
+  </g>
+  <g fill="#fff" font-family="Inter, Arial, sans-serif">
+    <text x="90" y="170" font-size="66" font-weight="700">Crédito Verde</text>
+    <text x="90" y="250" font-size="36" opacity="0.92">Financiamento para energia limpa e eficiência</text>
+  </g>
+  <g>
+    <rect x="180" y="560" width="180" height="170" fill="#b7f7c0"/>
+    <rect x="430" y="500" width="180" height="230" fill="#94e7a1"/>
+    <rect x="680" y="430" width="180" height="300" fill="#6fd986"/>
+    <rect x="930" y="370" width="180" height="360" fill="#45c96b"/>
+    <rect x="1180" y="300" width="180" height="430" fill="#18b957"/>
+  </g>
+</svg>

--- a/images/infraestrutura-digital.svg
+++ b/images/infraestrutura-digital.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-label="Ilustração de infraestrutura digital em cidade conectada">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#0b5fff"/>
+      <stop offset="100%" stop-color="#0a2f73"/>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#bg)"/>
+  <g fill="#ffffff" fill-opacity="0.15">
+    <circle cx="250" cy="180" r="110"/>
+    <circle cx="1350" cy="740" r="140"/>
+    <circle cx="920" cy="260" r="90"/>
+  </g>
+  <g fill="#fff" font-family="Inter, Arial, sans-serif">
+    <text x="90" y="170" font-size="66" font-weight="700">Infraestrutura Digital</text>
+    <text x="90" y="250" font-size="36" opacity="0.9">Conectividade para escolas, saúde e serviços públicos</text>
+  </g>
+  <g stroke="#8ec5ff" stroke-width="6" fill="none" opacity="0.9">
+    <path d="M140 640 L420 500 L700 620 L980 460 L1260 590 L1460 450"/>
+    <circle cx="420" cy="500" r="15" fill="#8ec5ff"/>
+    <circle cx="700" cy="620" r="15" fill="#8ec5ff"/>
+    <circle cx="980" cy="460" r="15" fill="#8ec5ff"/>
+    <circle cx="1260" cy="590" r="15" fill="#8ec5ff"/>
+  </g>
+</svg>

--- a/images/vacinacao.svg
+++ b/images/vacinacao.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-label="Ilustração de campanha de vacinação em saúde pública">
+  <defs>
+    <linearGradient id="bg3" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#0f4c9c"/>
+      <stop offset="100%" stop-color="#7129b8"/>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#bg3)"/>
+  <g fill="#fff" font-family="Inter, Arial, sans-serif">
+    <text x="90" y="170" font-size="66" font-weight="700">Mutirão de Vacinação</text>
+    <text x="90" y="250" font-size="36" opacity="0.9">Cobertura ampliada em centenas de municípios</text>
+  </g>
+  <g fill="#fff" fill-opacity="0.15">
+    <circle cx="300" cy="700" r="130"/>
+    <circle cx="1310" cy="230" r="110"/>
+  </g>
+  <g fill="#d9e7ff">
+    <rect x="550" y="420" width="500" height="70" rx="20"/>
+    <rect x="765" y="250" width="70" height="400" rx="20"/>
+  </g>
+  <g fill="#ffffff">
+    <rect x="740" y="350" width="120" height="220" rx="18"/>
+    <rect x="775" y="570" width="50" height="160" rx="20"/>
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Jornal Agora | Notícias de Política, Economia, Saúde e Tecnologia</title>
+  <meta name="description" content="Portal Jornal Agora com cobertura diária de política, economia, saúde e tecnologia, com reportagens originais e análises aprofundadas." />
+  <meta name="robots" content="index,follow,max-image-preview:large" />
+  <meta name="author" content="Redação Jornal Agora" />
+  <link rel="canonical" href="https://www.jornalagora.com.br/" />
+  <link rel="alternate" type="application/rss+xml" title="Jornal Agora RSS" href="https://www.jornalagora.com.br/feed.xml" />
+  <link rel="icon" href="images/infraestrutura-digital.svg" type="image/svg+xml" />
+
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Jornal Agora" />
+  <meta property="og:title" content="Jornal Agora | Notícias de Política, Economia, Saúde e Tecnologia" />
+  <meta property="og:description" content="Reportagens originais com foco em impacto social, economia real e políticas públicas." />
+  <meta property="og:url" content="https://www.jornalagora.com.br/" />
+  <meta property="og:image" content="https://www.jornalagora.com.br/images/infraestrutura-digital.svg" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Jornal Agora | Notícias de Política, Economia, Saúde e Tecnologia" />
+  <meta name="twitter:description" content="Reportagens originais com foco em impacto social, economia real e políticas públicas." />
+  <meta name="twitter:image" content="https://www.jornalagora.com.br/images/infraestrutura-digital.svg" />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css" />
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Organization",
+        "name": "Jornal Agora",
+        "url": "https://www.jornalagora.com.br/",
+        "logo": "https://www.jornalagora.com.br/images/infraestrutura-digital.svg"
+      },
+      {
+        "@type": "WebSite",
+        "name": "Jornal Agora",
+        "url": "https://www.jornalagora.com.br/",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "https://www.jornalagora.com.br/?q={search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
+  <header class="topbar">
+    <div class="container topbar-content">
+      <a class="logo" href="index.html">Jornal <span>Agora</span></a>
+      <nav class="top-nav">
+        <a href="index.html">Início</a>
+        <a href="sobre.html">Sobre</a>
+        <a href="contato.html">Contato</a>
+        <a href="politica-de-privacidade.html">Privacidade</a>
+        <a href="termos-de-uso.html">Termos</a>
+        <a href="autores.html">Autores</a>
+        <a href="politica-editorial.html">Editorial</a>
+      </nav>
+      <button id="themeToggle" class="theme-toggle" aria-label="Alternar tema">🌙</button>
+    </div>
+  </header>
+
+  <main class="container main-layout">
+    <section class="card hero">
+      <img class="hero-image" src="images/infraestrutura-digital.svg" alt="Cidade conectada representando infraestrutura digital" loading="eager" />
+      <p class="tag">Destaque editorial</p>
+      <h1>Plano nacional de infraestrutura digital mira inclusão de 20 milhões de brasileiros</h1>
+      <p>A medida prevê investimento em conectividade escolar, rede pública de saúde e capacitação técnica regional até 2028.</p>
+      <a class="button" href="noticia-infraestrutura-digital.html">Ler matéria completa</a>
+    </section>
+
+    <aside class="card sidebar">
+      <h2>Últimas publicações</h2>
+      <span class="badge-ok">Conteúdo original</span>
+      <ul class="latest-list" id="latestNewsList">
+        <li><time>08:00</time><a href="noticia-infraestrutura-digital.html">Infraestrutura digital entra na pauta federal</a></li>
+        <li><time>09:20</time><a href="noticia-credito-verde.html">Bancos ampliam crédito para energia limpa</a></li>
+        <li><time>10:15</time><a href="noticia-vacinacao.html">Campanha de vacinação tem meta reforçada</a></li>
+      </ul>
+    </aside>
+
+    <section class="card section publish-section">
+      <h2>Publicar notícia no Supabase</h2>
+      <p class="article-meta">Publicação persistida no banco de dados para ser exibida para todos os visitantes.</p>
+      <form id="publishForm" class="publish-form">
+        <input id="title" name="title" type="text" placeholder="Título da notícia" required maxlength="140" />
+        <input id="category" name="category" type="text" placeholder="Categoria (ex: Economia)" required maxlength="40" />
+        <input id="author" name="author" type="text" placeholder="Autor (ex: Redação)" required maxlength="80" />
+        <textarea id="summary" name="summary" rows="3" placeholder="Resumo da notícia" required maxlength="260"></textarea>
+        <button class="button" type="submit">Publicar</button>
+      </form>
+      <p id="publishStatus" class="status"></p>
+    </section>
+
+    <section class="card section">
+      <h2>Notícias em destaque</h2>
+      <div class="grid" id="newsGrid">
+        <article class="article-card">
+          <img src="images/infraestrutura-digital.svg" alt="Ilustração de infraestrutura digital" loading="lazy" />
+          <p class="article-meta">Política • 9 min de leitura</p>
+          <h3><a href="noticia-infraestrutura-digital.html">Governo anuncia plano de infraestrutura digital</a></h3>
+          <p>Entenda os impactos práticos para escolas, hospitais e pequenas empresas.</p>
+        </article>
+        <article class="article-card">
+          <img src="images/credito-verde.svg" alt="Ilustração sobre crédito verde" loading="lazy" />
+          <p class="article-meta">Economia • 7 min de leitura</p>
+          <h3><a href="noticia-credito-verde.html">Crédito verde ganha força no setor produtivo</a></h3>
+          <p>Linhas de financiamento com juros menores atraem pequenas e médias empresas.</p>
+        </article>
+        <article class="article-card">
+          <img src="images/vacinacao.svg" alt="Ilustração de campanha de vacinação" loading="lazy" />
+          <p class="article-meta">Saúde • 6 min de leitura</p>
+          <h3><a href="noticia-vacinacao.html">Municípios ampliam mutirões de vacinação</a></h3>
+          <p>Secretarias reforçam ações para aumentar cobertura e reduzir filas.</p>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-links">
+        <a href="sobre.html">Sobre</a>
+        <a href="contato.html">Contato</a>
+        <a href="politica-de-privacidade.html">Política de Privacidade</a>
+        <a href="termos-de-uso.html">Termos de Uso</a>
+        <a href="autores.html">Autores</a>
+        <a href="politica-editorial.html">Política Editorial</a>
+      </div>
+      <p>© 2026 Jornal Agora — Jornalismo independente e informação verificada.</p>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+  <script type="module" src="supabase-news.js"></script>
+</body>
+</html>

--- a/noticia-credito-verde.html
+++ b/noticia-credito-verde.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Crédito verde ganha força no setor produtivo | Jornal Agora</title>
+  <meta name="description" content="Linhas de crédito verde crescem no Brasil e impulsionam modernização energética de empresas." />
+  <meta name="robots" content="index,follow,max-image-preview:large" />
+  <meta name="author" content="Redação Economia" />
+  <link rel="canonical" href="https://www.jornalagora.com.br/noticia-credito-verde.html" />
+
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="Crédito verde ganha força e acelera projetos sustentáveis" />
+  <meta property="og:description" content="Linhas de financiamento com juros reduzidos ampliam investimentos em eficiência energética." />
+  <meta property="og:url" content="https://www.jornalagora.com.br/noticia-credito-verde.html" />
+  <meta property="og:image" content="https://www.jornalagora.com.br/images/credito-verde.svg" />
+  <meta property="article:published_time" content="2026-02-09T09:20:00-03:00" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Crédito verde ganha força e acelera projetos sustentáveis" />
+  <meta name="twitter:description" content="Linhas de financiamento com juros reduzidos ampliam investimentos em eficiência energética." />
+  <meta name="twitter:image" content="https://www.jornalagora.com.br/images/credito-verde.svg" />
+
+  <link rel="stylesheet" href="styles.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "NewsArticle",
+    "headline": "Crédito verde ganha força e acelera projetos sustentáveis",
+    "datePublished": "2026-02-09T09:20:00-03:00",
+    "dateModified": "2026-02-09T09:20:00-03:00",
+    "author": {"@type": "Person", "name": "Redação Economia"},
+    "publisher": {
+      "@type": "Organization",
+      "name": "Jornal Agora",
+      "logo": {"@type": "ImageObject", "url": "https://www.jornalagora.com.br/images/infraestrutura-digital.svg"}
+    },
+    "image": ["https://www.jornalagora.com.br/images/credito-verde.svg"],
+    "mainEntityOfPage": "https://www.jornalagora.com.br/noticia-credito-verde.html",
+    "description": "Linhas de crédito verde crescem no Brasil e impulsionam modernização energética de empresas."
+  }
+  </script>
+</head>
+<body>
+  <header class="topbar">
+    <div class="container topbar-content">
+      <a class="logo" href="index.html">Jornal <span>Agora</span></a>
+      <nav class="top-nav">
+        <a href="index.html">Início</a>
+        <a href="sobre.html">Sobre</a>
+        <a href="contato.html">Contato</a>
+        <a href="politica-de-privacidade.html">Privacidade</a>
+        <a href="termos-de-uso.html">Termos</a>
+        <a href="autores.html">Autores</a>
+        <a href="politica-editorial.html">Editorial</a>
+      </nav>
+      <button id="themeToggle" class="theme-toggle" aria-label="Alternar tema">🌙</button>
+    </div>
+  </header>
+
+  <main class="container page">
+    <article class="card content article-body">
+      <p class="article-meta">Publicado em 09/02/2026 • Atualizado em 09/02/2026 • Por <a href="autores.html">Redação Economia</a></p>
+      <h1>Crédito verde ganha força e acelera projetos sustentáveis</h1>
+      <img class="article-cover" src="images/credito-verde.svg" alt="Ilustração de crédito verde" loading="eager" />
+      <p>Bancos públicos e privados ampliaram a oferta de crédito para projetos de eficiência energética e geração renovável. As novas linhas têm prazos maiores e juros reduzidos para empresas que comprovem impacto ambiental positivo.</p>
+      <p>Em levantamento da associação do setor, a procura por financiamento para retrofit energético subiu 34% no último trimestre. Entre os setores com maior demanda estão indústria de alimentos, logística e varejo.</p>
+      <p>Analistas apontam que o avanço do crédito verde ajuda empresas a reduzir custos operacionais, melhorar indicadores de sustentabilidade e atender exigências de cadeias internacionais de fornecimento.</p>
+    </article>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-links">
+        <a href="sobre.html">Sobre</a>
+        <a href="contato.html">Contato</a>
+        <a href="politica-de-privacidade.html">Política de Privacidade</a>
+        <a href="termos-de-uso.html">Termos de Uso</a>
+        <a href="autores.html">Autores</a>
+        <a href="politica-editorial.html">Política Editorial</a>
+      </div>
+      <p>© 2026 Jornal Agora.</p>
+    </div>
+  </footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/noticia-infraestrutura-digital.html
+++ b/noticia-infraestrutura-digital.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Governo anuncia plano de infraestrutura digital | Jornal Agora</title>
+  <meta name="description" content="Plano federal de infraestrutura digital prevê investimentos em conectividade para escolas, saúde e serviços públicos." />
+  <meta name="robots" content="index,follow,max-image-preview:large" />
+  <meta name="author" content="Redação Jornal Agora" />
+  <link rel="canonical" href="https://www.jornalagora.com.br/noticia-infraestrutura-digital.html" />
+
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="Governo anuncia plano de infraestrutura digital" />
+  <meta property="og:description" content="Plano federal amplia conectividade para escolas, saúde e pequenos negócios." />
+  <meta property="og:url" content="https://www.jornalagora.com.br/noticia-infraestrutura-digital.html" />
+  <meta property="og:image" content="https://www.jornalagora.com.br/images/infraestrutura-digital.svg" />
+  <meta property="article:published_time" content="2026-02-09T08:00:00-03:00" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Governo anuncia plano de infraestrutura digital" />
+  <meta name="twitter:description" content="Plano federal amplia conectividade para escolas, saúde e pequenos negócios." />
+  <meta name="twitter:image" content="https://www.jornalagora.com.br/images/infraestrutura-digital.svg" />
+
+  <link rel="stylesheet" href="styles.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "NewsArticle",
+    "headline": "Governo anuncia plano de infraestrutura digital para ampliar inclusão",
+    "datePublished": "2026-02-09T08:00:00-03:00",
+    "dateModified": "2026-02-09T08:00:00-03:00",
+    "author": {"@type": "Person", "name": "Redação Jornal Agora"},
+    "publisher": {
+      "@type": "Organization",
+      "name": "Jornal Agora",
+      "logo": {"@type": "ImageObject", "url": "https://www.jornalagora.com.br/images/infraestrutura-digital.svg"}
+    },
+    "image": ["https://www.jornalagora.com.br/images/infraestrutura-digital.svg"],
+    "mainEntityOfPage": "https://www.jornalagora.com.br/noticia-infraestrutura-digital.html",
+    "description": "Plano federal de infraestrutura digital prevê investimentos em conectividade para escolas, saúde e serviços públicos."
+  }
+  </script>
+</head>
+<body>
+  <header class="topbar">
+    <div class="container topbar-content">
+      <a class="logo" href="index.html">Jornal <span>Agora</span></a>
+      <nav class="top-nav">
+        <a href="index.html">Início</a>
+        <a href="sobre.html">Sobre</a>
+        <a href="contato.html">Contato</a>
+        <a href="politica-de-privacidade.html">Privacidade</a>
+        <a href="termos-de-uso.html">Termos</a>
+        <a href="autores.html">Autores</a>
+        <a href="politica-editorial.html">Editorial</a>
+      </nav>
+      <button id="themeToggle" class="theme-toggle" aria-label="Alternar tema">🌙</button>
+    </div>
+  </header>
+
+  <main class="container page">
+    <article class="card content article-body">
+      <p class="article-meta">Publicado em 09/02/2026 • Atualizado em 09/02/2026 • Por <a href="autores.html">Redação Jornal Agora</a></p>
+      <h1>Governo anuncia plano de infraestrutura digital para ampliar inclusão</h1>
+      <img class="article-cover" src="images/infraestrutura-digital.svg" alt="Ilustração de infraestrutura digital" loading="eager" />
+      <p>O novo plano nacional de infraestrutura digital foi apresentado com foco em ampliar o acesso à internet de alta velocidade em regiões com baixa cobertura. Segundo o ministério responsável, a meta é atender 20 milhões de brasileiros até 2028.</p>
+      <p>O programa terá três frentes prioritárias: conectividade escolar, integração de dados em unidades de saúde e expansão da infraestrutura para pequenos negócios em áreas periféricas. O investimento total estimado é de R$ 18 bilhões, com participação pública e privada.</p>
+      <p>Especialistas ouvidos pela reportagem destacam que a execução local será decisiva para o sucesso. Municípios com planejamento técnico e integração entre secretarias tendem a capturar mais recursos e acelerar resultados.</p>
+      <h2>Impactos esperados</h2>
+      <ul>
+        <li>Melhora de serviços públicos digitais para a população.</li>
+        <li>Redução de desigualdade no acesso à educação online.</li>
+        <li>Aumento de produtividade para pequenos empreendedores.</li>
+      </ul>
+    </article>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-links">
+        <a href="sobre.html">Sobre</a>
+        <a href="contato.html">Contato</a>
+        <a href="politica-de-privacidade.html">Política de Privacidade</a>
+        <a href="termos-de-uso.html">Termos de Uso</a>
+        <a href="autores.html">Autores</a>
+        <a href="politica-editorial.html">Política Editorial</a>
+      </div>
+      <p>© 2026 Jornal Agora.</p>
+    </div>
+  </footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/noticia-vacinacao.html
+++ b/noticia-vacinacao.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Municípios ampliam mutirões de vacinação | Jornal Agora</title>
+  <meta name="description" content="Municípios reforçam mutirões e horários estendidos para elevar cobertura vacinal." />
+  <meta name="robots" content="index,follow,max-image-preview:large" />
+  <meta name="author" content="Redação Saúde" />
+  <link rel="canonical" href="https://www.jornalagora.com.br/noticia-vacinacao.html" />
+
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="Mutirões de vacinação são ampliados em mais de 200 cidades" />
+  <meta property="og:description" content="Secretarias de saúde reforçam vacinação com horários estendidos e pontos itinerantes." />
+  <meta property="og:url" content="https://www.jornalagora.com.br/noticia-vacinacao.html" />
+  <meta property="og:image" content="https://www.jornalagora.com.br/images/vacinacao.svg" />
+  <meta property="article:published_time" content="2026-02-09T10:15:00-03:00" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Mutirões de vacinação são ampliados em mais de 200 cidades" />
+  <meta name="twitter:description" content="Secretarias de saúde reforçam vacinação com horários estendidos e pontos itinerantes." />
+  <meta name="twitter:image" content="https://www.jornalagora.com.br/images/vacinacao.svg" />
+
+  <link rel="stylesheet" href="styles.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "NewsArticle",
+    "headline": "Mutirões de vacinação são ampliados em mais de 200 cidades",
+    "datePublished": "2026-02-09T10:15:00-03:00",
+    "dateModified": "2026-02-09T10:15:00-03:00",
+    "author": {"@type": "Person", "name": "Redação Saúde"},
+    "publisher": {
+      "@type": "Organization",
+      "name": "Jornal Agora",
+      "logo": {"@type": "ImageObject", "url": "https://www.jornalagora.com.br/images/infraestrutura-digital.svg"}
+    },
+    "image": ["https://www.jornalagora.com.br/images/vacinacao.svg"],
+    "mainEntityOfPage": "https://www.jornalagora.com.br/noticia-vacinacao.html",
+    "description": "Municípios reforçam mutirões e horários estendidos para elevar cobertura vacinal."
+  }
+  </script>
+</head>
+<body>
+  <header class="topbar">
+    <div class="container topbar-content">
+      <a class="logo" href="index.html">Jornal <span>Agora</span></a>
+      <nav class="top-nav">
+        <a href="index.html">Início</a>
+        <a href="sobre.html">Sobre</a>
+        <a href="contato.html">Contato</a>
+        <a href="politica-de-privacidade.html">Privacidade</a>
+        <a href="termos-de-uso.html">Termos</a>
+        <a href="autores.html">Autores</a>
+        <a href="politica-editorial.html">Editorial</a>
+      </nav>
+      <button id="themeToggle" class="theme-toggle" aria-label="Alternar tema">🌙</button>
+    </div>
+  </header>
+
+  <main class="container page">
+    <article class="card content article-body">
+      <p class="article-meta">Publicado em 09/02/2026 • Atualizado em 09/02/2026 • Por <a href="autores.html">Redação Saúde</a></p>
+      <h1>Mutirões de vacinação são ampliados em mais de 200 cidades</h1>
+      <img class="article-cover" src="images/vacinacao.svg" alt="Ilustração de mutirão de vacinação" loading="eager" />
+      <p>Secretarias municipais de saúde anunciaram novos mutirões com horários estendidos e pontos itinerantes para aumentar a cobertura vacinal. A ação prioriza públicos em atraso e áreas com menor acesso.</p>
+      <p>Dados preliminares apontam aumento de 19% no comparecimento após campanhas locais com busca ativa e parcerias com escolas e associações comunitárias.</p>
+      <p>Autoridades reforçam que a vacinação em dia reduz internações evitáveis e fortalece o sistema público, especialmente em períodos de maior circulação de doenças respiratórias.</p>
+    </article>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-links">
+        <a href="sobre.html">Sobre</a>
+        <a href="contato.html">Contato</a>
+        <a href="politica-de-privacidade.html">Política de Privacidade</a>
+        <a href="termos-de-uso.html">Termos de Uso</a>
+        <a href="autores.html">Autores</a>
+        <a href="politica-editorial.html">Política Editorial</a>
+      </div>
+      <p>© 2026 Jornal Agora.</p>
+    </div>
+  </footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/politica-de-privacidade.html
+++ b/politica-de-privacidade.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Política de Privacidade | Jornal Agora</title>
+  <meta name="description" content="Política de privacidade e tratamento de dados do Jornal Agora." />
+  <meta name="robots" content="index,follow" />
+  <link rel="canonical" href="https://www.jornalagora.com.br/politica-de-privacidade.html" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="topbar"><div class="container topbar-content"><a class="logo" href="index.html">Jornal <span>Agora</span></a><nav class="top-nav"><a href="index.html">Início</a><a href="sobre.html">Sobre</a><a href="contato.html">Contato</a><a href="politica-de-privacidade.html">Privacidade</a><a href="termos-de-uso.html">Termos</a>
+        <a href="autores.html">Autores</a>
+        <a href="politica-editorial.html">Editorial</a></nav><button id="themeToggle" class="theme-toggle" aria-label="Alternar tema">🌙</button></div></header>
+  <main class="container page">
+    <section class="card content article-body">
+      <h1>Política de Privacidade</h1>
+      <p>Esta página descreve como o Jornal Agora coleta, utiliza e protege informações dos usuários, em conformidade com a legislação aplicável.</p>
+      <h2>Dados coletados</h2>
+      <p>Podemos coletar dados de navegação para melhorar desempenho, experiência e segurança do site.</p>
+      <h2>Cookies e publicidade</h2>
+      <p>Utilizamos cookies para funcionalidades básicas. Serviços de publicidade podem usar cookies para personalização e medição, conforme suas políticas próprias.</p>
+      <h2>Direitos do usuário</h2>
+      <p>Você pode solicitar informações, correção ou remoção de dados pessoais pelo e-mail de contato informado nesta página.</p>
+    </section>
+  </main>
+  <footer class="footer"><div class="container"><div class="footer-links"><a href="sobre.html">Sobre</a><a href="contato.html">Contato</a><a href="politica-de-privacidade.html">Política de Privacidade</a><a href="termos-de-uso.html">Termos de Uso</a>
+        <a href="autores.html">Autores</a>
+        <a href="politica-editorial.html">Política Editorial</a></div><p>© 2026 Jornal Agora.</p></div></footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/politica-editorial.html
+++ b/politica-editorial.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Política Editorial | Jornal Agora</title>
+  <meta name="description" content="Princípios editoriais, metodologia de apuração, correções e diretrizes de independência do Jornal Agora." />
+  <meta name="robots" content="index,follow" />
+  <link rel="canonical" href="https://www.jornalagora.com.br/politica-editorial.html" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="container topbar-content">
+      <a class="logo" href="index.html">Jornal <span>Agora</span></a>
+      <nav class="top-nav">
+        <a href="index.html">Início</a>
+        <a href="sobre.html">Sobre</a>
+        <a href="contato.html">Contato</a>
+        <a href="politica-de-privacidade.html">Privacidade</a>
+        <a href="termos-de-uso.html">Termos</a>
+        <a href="autores.html">Autores</a>
+        <a href="politica-editorial.html">Editorial</a>
+      </nav>
+      <button id="themeToggle" class="theme-toggle" aria-label="Alternar tema">🌙</button>
+    </div>
+  </header>
+
+  <main class="container page">
+    <section class="card content article-body">
+      <h1>Política Editorial</h1>
+      <p>O Jornal Agora adota padrões editoriais voltados para precisão, contexto e interesse público.</p>
+
+      <h2>1. Apuração e verificação</h2>
+      <p>Toda matéria deve ser baseada em fontes verificáveis, documentos públicos, entrevistas identificadas e dados auditáveis.</p>
+
+      <h2>2. Independência editorial</h2>
+      <p>Nossa redação atua de forma independente de interesses comerciais. Conteúdo patrocinado é sempre identificado de forma explícita.</p>
+
+      <h2>3. Correções e atualizações</h2>
+      <p>Quando erros factuais são identificados, publicamos correções com transparência, incluindo data de atualização e trecho corrigido.</p>
+
+      <h2>4. Conflito de interesses</h2>
+      <p>Autores e editores devem informar potenciais conflitos e, quando necessário, se declarar impedidos de cobrir determinado tema.</p>
+
+      <h2>5. Contato da editoria</h2>
+      <p>Pedidos de correção e manifestações podem ser enviados para <a href="mailto:redacao@jornalagora.com.br">redacao@jornalagora.com.br</a>.</p>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-links">
+        <a href="sobre.html">Sobre</a>
+        <a href="contato.html">Contato</a>
+        <a href="politica-de-privacidade.html">Política de Privacidade</a>
+        <a href="termos-de-uso.html">Termos de Uso</a>
+        <a href="autores.html">Autores</a>
+        <a href="politica-editorial.html">Política Editorial</a>
+      </div>
+      <p>© 2026 Jornal Agora.</p>
+    </div>
+  </footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.jornalagora.com.br/sitemap.xml
+Sitemap: https://www.jornalagora.com.br/feed.xml

--- a/script.js
+++ b/script.js
@@ -1,0 +1,17 @@
+const toggle = document.getElementById('themeToggle');
+const THEME_STORAGE_KEY = 'news-theme';
+
+if (toggle) {
+  const storedTheme = localStorage.getItem(THEME_STORAGE_KEY);
+
+  if (storedTheme === 'dark') {
+    document.body.classList.add('dark');
+    toggle.textContent = '☀️';
+  }
+
+  toggle.addEventListener('click', () => {
+    const isDark = document.body.classList.toggle('dark');
+    localStorage.setItem(THEME_STORAGE_KEY, isDark ? 'dark' : 'light');
+    toggle.textContent = isDark ? '☀️' : '🌙';
+  });
+}

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.jornalagora.com.br/</loc>
+    <lastmod>2026-02-10</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://www.jornalagora.com.br/noticia-infraestrutura-digital.html</loc>
+    <lastmod>2026-02-10</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://www.jornalagora.com.br/noticia-credito-verde.html</loc>
+    <lastmod>2026-02-10</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://www.jornalagora.com.br/noticia-vacinacao.html</loc>
+    <lastmod>2026-02-10</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url><loc>https://www.jornalagora.com.br/sobre.html</loc></url>
+  <url><loc>https://www.jornalagora.com.br/contato.html</loc></url>
+  <url><loc>https://www.jornalagora.com.br/politica-de-privacidade.html</loc></url>
+  <url><loc>https://www.jornalagora.com.br/termos-de-uso.html</loc></url>
+  <url><loc>https://www.jornalagora.com.br/autores.html</loc></url>
+  <url><loc>https://www.jornalagora.com.br/politica-editorial.html</loc></url>
+</urlset>

--- a/sobre.html
+++ b/sobre.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sobre o Jornal Agora</title>
+  <meta name="description" content="Conheça a missão editorial, princípios de apuração e compromisso com conteúdo original do Jornal Agora." />
+  <meta name="robots" content="index,follow" />
+  <link rel="canonical" href="https://www.jornalagora.com.br/sobre.html" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="container topbar-content">
+      <a class="logo" href="index.html">Jornal <span>Agora</span></a>
+      <nav class="top-nav">
+        <a href="index.html">Início</a><a href="sobre.html">Sobre</a><a href="contato.html">Contato</a><a href="politica-de-privacidade.html">Privacidade</a><a href="termos-de-uso.html">Termos</a>
+        <a href="autores.html">Autores</a>
+        <a href="politica-editorial.html">Editorial</a>
+      </nav>
+      <button id="themeToggle" class="theme-toggle" aria-label="Alternar tema">🌙</button>
+    </div>
+  </header>
+  <main class="container page">
+    <section class="card content article-body">
+      <h1>Sobre o Jornal Agora</h1>
+      <p>O Jornal Agora é um portal editorial independente com foco em cobertura factual de política pública, economia real e impacto social.</p>
+      <p>Nossa missão é publicar conteúdo original, apurado e contextualizado, em linguagem clara e com transparência sobre fontes.</p>
+      <h2>Princípios editoriais</h2>
+      <ul>
+        <li>Verificação de informações antes da publicação.</li>
+        <li>Correção pública de eventuais erros factuais.</li>
+        <li>Separação clara entre conteúdo editorial e publicitário.</li>
+      </ul>
+    </section>
+  </main>
+  <footer class="footer">
+    <div class="container"><div class="footer-links"><a href="sobre.html">Sobre</a><a href="contato.html">Contato</a><a href="politica-de-privacidade.html">Política de Privacidade</a><a href="termos-de-uso.html">Termos de Uso</a>
+        <a href="autores.html">Autores</a>
+        <a href="politica-editorial.html">Política Editorial</a></div><p>© 2026 Jornal Agora.</p></div>
+  </footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,318 @@
+:root {
+  --bg: #f4f7fb;
+  --surface: #ffffff;
+  --surface-alt: #eef3fa;
+  --text: #172231;
+  --muted: #5d6d80;
+  --primary: #0d5eff;
+  --border: #d8e2ef;
+  --success: #0a7a37;
+  --shadow: 0 12px 28px rgba(15, 35, 61, 0.08);
+}
+
+body.dark {
+  --bg: #0d1622;
+  --surface: #152334;
+  --surface-alt: #1b2d43;
+  --text: #e8f0fb;
+  --muted: #b2c3d9;
+  --primary: #76a6ff;
+  --border: #2d415b;
+  --success: #50d68a;
+  --shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+a {
+  color: var(--primary);
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.container {
+  width: min(1100px, 92vw);
+  margin: 0 auto;
+}
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(10px);
+  background: color-mix(in srgb, var(--surface) 92%, transparent);
+  border-bottom: 1px solid var(--border);
+}
+
+.topbar-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.95rem 0;
+}
+
+.logo {
+  font-size: 1.3rem;
+  font-weight: 800;
+  text-decoration: none;
+  color: var(--text);
+}
+
+.logo span {
+  color: var(--primary);
+}
+
+.top-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.9rem;
+}
+
+.top-nav a {
+  text-decoration: none;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.theme-toggle {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  width: 2.2rem;
+  height: 2.2rem;
+  cursor: pointer;
+  background: var(--surface);
+  color: var(--text);
+}
+
+.main-layout {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 1rem;
+  margin: 1.2rem auto 2rem;
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: var(--shadow);
+}
+
+.hero {
+  padding: 1.2rem;
+}
+
+.hero-image {
+  width: 100%;
+  border-radius: 12px;
+  margin-bottom: 1rem;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+}
+
+.hero .tag {
+  color: var(--primary);
+  font-weight: 800;
+  margin: 0;
+}
+
+.hero h1 {
+  margin: 0.6rem 0;
+  font-size: clamp(1.6rem, 2.8vw, 2.3rem);
+}
+
+.hero p {
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.button {
+  display: inline-block;
+  background: var(--primary);
+  color: #fff;
+  text-decoration: none;
+  font-weight: 700;
+  border-radius: 10px;
+  padding: 0.7rem 1rem;
+  border: 0;
+  cursor: pointer;
+}
+
+.sidebar {
+  padding: 1.2rem;
+}
+
+.sidebar h2,
+.section h2 {
+  margin-top: 0;
+}
+
+.latest-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.latest-list li {
+  padding: 0.75rem 0;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+}
+
+.latest-list li:first-child {
+  border-top: 0;
+  padding-top: 0;
+}
+
+.latest-list time {
+  font-weight: 700;
+  color: var(--text);
+  margin-right: 0.4rem;
+}
+
+.badge-ok {
+  display: inline-block;
+  background: color-mix(in srgb, var(--success) 16%, transparent);
+  color: var(--success);
+  border: 1px solid color-mix(in srgb, var(--success) 45%, transparent);
+  font-size: 0.8rem;
+  font-weight: 700;
+  padding: 0.25rem 0.55rem;
+  border-radius: 999px;
+}
+
+.section {
+  grid-column: 1 / -1;
+  padding: 1.2rem;
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.article-card {
+  padding: 1rem;
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+}
+
+.article-card img {
+  border-radius: 10px;
+  margin-bottom: 0.7rem;
+  width: 100%;
+  aspect-ratio: 16/9;
+  object-fit: cover;
+}
+
+.article-card h3 {
+  margin-top: 0;
+}
+
+.article-card p {
+  color: var(--muted);
+}
+
+.article-meta {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.page {
+  margin: 1.2rem auto 2rem;
+}
+
+.page .content {
+  padding: 1.4rem;
+}
+
+.page h1 {
+  margin-top: 0;
+}
+
+.article-cover {
+  border-radius: 12px;
+  margin: 0.8rem 0 1rem;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+}
+
+.article-body p,
+.article-body li {
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.footer {
+  border-top: 1px solid var(--border);
+  padding: 1.3rem 0 2rem;
+  color: var(--muted);
+  text-align: center;
+}
+
+.footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.5rem;
+}
+
+.publish-section {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.publish-form {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.publish-form input,
+.publish-form textarea {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.65rem 0.75rem;
+  font: inherit;
+  background: var(--surface);
+  color: var(--text);
+}
+
+.status {
+  min-height: 1.3rem;
+  margin: 0;
+  color: var(--success);
+  font-weight: 600;
+}
+
+.status.error {
+  color: #c03838;
+}
+
+@media (max-width: 860px) {
+  .main-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .top-nav {
+    display: none;
+  }
+}

--- a/supabase-news.js
+++ b/supabase-news.js
@@ -1,0 +1,120 @@
+import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm';
+
+const SUPABASE_URL = 'https://owwdkyayohwrnagramcp.supabase.co';
+const SUPABASE_ANON_KEY = 'sb_publishable_i1sYpTp67FYqJtpP83rWyQ_pQsTd7fX';
+const TABLE_NAME = 'news_posts';
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+const newsGrid = document.getElementById('newsGrid');
+const latestNewsList = document.getElementById('latestNewsList');
+const publishForm = document.getElementById('publishForm');
+const publishStatus = document.getElementById('publishStatus');
+
+function formatTime(dateString) {
+  const d = new Date(dateString);
+  if (Number.isNaN(d.getTime())) return '--:--';
+  return d.toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' });
+}
+
+function imageByCategory(category) {
+  const normalized = category.toLowerCase();
+  if (normalized.includes('saúde')) return 'images/vacinacao.svg';
+  if (normalized.includes('econom')) return 'images/credito-verde.svg';
+  return 'images/infraestrutura-digital.svg';
+}
+
+function setStatus(message, isError = false) {
+  if (!publishStatus) return;
+  publishStatus.textContent = message;
+  publishStatus.classList.toggle('error', isError);
+}
+
+function removeDynamicNodes() {
+  newsGrid?.querySelectorAll('[data-dynamic="true"]').forEach((card) => card.remove());
+  latestNewsList?.querySelectorAll('[data-dynamic="true"]').forEach((item) => item.remove());
+}
+
+function createTextElement(tag, text, className) {
+  const el = document.createElement(tag);
+  if (className) el.className = className;
+  el.textContent = text;
+  return el;
+}
+
+function renderNews(posts) {
+  removeDynamicNodes();
+  if (!newsGrid || !latestNewsList) return;
+
+  posts.forEach((post) => {
+    const article = document.createElement('article');
+    article.className = 'article-card';
+    article.dataset.dynamic = 'true';
+
+    const image = document.createElement('img');
+    image.src = imageByCategory(post.category);
+    image.alt = `Ilustração da categoria ${post.category}`;
+    image.loading = 'lazy';
+
+    const meta = createTextElement('p', `${post.category} • ${post.author} • ${formatTime(post.created_at)}`, 'article-meta');
+    const title = createTextElement('h3', post.title);
+    const summary = createTextElement('p', post.summary);
+
+    article.append(image, meta, title, summary);
+    newsGrid.prepend(article);
+
+    const latest = document.createElement('li');
+    latest.dataset.dynamic = 'true';
+    const time = createTextElement('time', formatTime(post.created_at));
+    latest.append(time, document.createTextNode(post.title));
+    latestNewsList.prepend(latest);
+  });
+}
+
+async function loadPosts() {
+  const { data, error } = await supabase
+    .from(TABLE_NAME)
+    .select('id,title,category,summary,author,created_at')
+    .order('created_at', { ascending: false })
+    .limit(6);
+
+  if (error) {
+    setStatus('Não foi possível carregar notícias do Supabase. Confira tabela/RLS.', true);
+    return;
+  }
+
+  renderNews(data ?? []);
+}
+
+if (publishForm) {
+  publishForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+
+    const formData = new FormData(publishForm);
+    const payload = {
+      title: String(formData.get('title') ?? '').trim(),
+      category: String(formData.get('category') ?? '').trim(),
+      author: String(formData.get('author') ?? '').trim(),
+      summary: String(formData.get('summary') ?? '').trim(),
+    };
+
+    const hasEmpty = Object.values(payload).some((value) => !value);
+    if (hasEmpty) {
+      setStatus('Preencha todos os campos.', true);
+      return;
+    }
+
+    const { error } = await supabase.from(TABLE_NAME).insert(payload);
+
+    if (error) {
+      setStatus('Falha ao publicar no Supabase. Valide políticas RLS e estrutura da tabela.', true);
+      return;
+    }
+
+    setStatus('Notícia publicada com sucesso no Supabase.');
+    publishForm.reset();
+    await loadPosts();
+  });
+}
+
+loadPosts();

--- a/supabase-setup.sql
+++ b/supabase-setup.sql
@@ -1,0 +1,21 @@
+-- Execute no SQL Editor do Supabase
+create table if not exists public.news_posts (
+  id bigint generated always as identity primary key,
+  title text not null,
+  category text not null,
+  summary text not null,
+  author text not null,
+  created_at timestamptz not null default now()
+);
+
+alter table public.news_posts enable row level security;
+
+create policy "Leitura pública de notícias"
+on public.news_posts
+for select
+using (true);
+
+create policy "Inserção pública de notícias"
+on public.news_posts
+for insert
+with check (true);

--- a/termos-de-uso.html
+++ b/termos-de-uso.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Termos de Uso | Jornal Agora</title>
+  <meta name="description" content="Termos de uso do conteúdo e dos serviços oferecidos pelo Jornal Agora." />
+  <meta name="robots" content="index,follow" />
+  <link rel="canonical" href="https://www.jornalagora.com.br/termos-de-uso.html" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="topbar"><div class="container topbar-content"><a class="logo" href="index.html">Jornal <span>Agora</span></a><nav class="top-nav"><a href="index.html">Início</a><a href="sobre.html">Sobre</a><a href="contato.html">Contato</a><a href="politica-de-privacidade.html">Privacidade</a><a href="termos-de-uso.html">Termos</a>
+        <a href="autores.html">Autores</a>
+        <a href="politica-editorial.html">Editorial</a></nav><button id="themeToggle" class="theme-toggle" aria-label="Alternar tema">🌙</button></div></header>
+  <main class="container page">
+    <section class="card content article-body">
+      <h1>Termos de Uso</h1>
+      <p>Ao acessar o site, você concorda com estes termos. O conteúdo é protegido por direitos autorais e não pode ser reproduzido integralmente sem autorização.</p>
+      <h2>Uso permitido</h2>
+      <p>É permitido compartilhar links e pequenos trechos com atribuição da fonte.</p>
+      <h2>Limitação de responsabilidade</h2>
+      <p>Empenhamos boa-fé editorial, mas não garantimos ausência total de erros. Correções podem ser realizadas a qualquer momento.</p>
+      <h2>Atualizações</h2>
+      <p>Os termos podem ser alterados periodicamente para refletir mudanças legais e operacionais.</p>
+    </section>
+  </main>
+  <footer class="footer"><div class="container"><div class="footer-links"><a href="sobre.html">Sobre</a><a href="contato.html">Contato</a><a href="politica-de-privacidade.html">Política de Privacidade</a><a href="termos-de-uso.html">Termos de Uso</a>
+        <a href="autores.html">Autores</a>
+        <a href="politica-editorial.html">Política Editorial</a></div><p>© 2026 Jornal Agora.</p></div></footer>
+  <script src="script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Melhorar transparência editorial e sinais de autoria para reforçar E‑E‑A‑T e confiança dos leitores. 
- Tornar páginas institucionais indexáveis e acessíveis (Autores, Política Editorial) para rastreadores e leitores.
- Incluir artefatos e assets necessários para previews sociais e descoberta (meta tags, imagens, RSS, sitemap e robots). 
- Conectar frontend com uma tabela simples no Supabase para publicar e listar notícias dinamicamente.

### Description
- Adiciona duas páginas institucionais: `autores.html` (perfis editoriais) e `politica-editorial.html` (diretrizes de apuração, correções e contato da editoria). 
- Atualiza navegação e rodapé em páginas principais e artigos para incluir links a `Autores` e `Política Editorial`, e altera metadados/author nos artigos para apontar à página de autores. 
- Cria assets e SEO: `sitemap.xml`, `feed.xml` (RSS), `robots.txt`, `ads.txt` e imagens editoriais em `images/*.svg`, além de JSON‑LD em páginas principais e artigos para `Organization`/`WebSite`/`NewsArticle`. 
- Adiciona frontend/UX e estilo: `styles.css` (tema claro/escuro) e `script.js` (toggle de tema), e implementa integração Supabase em `supabase-news.js` com renderização segura via DOM. 
- Fornece esquema e políticas mínimas para Pub/Sub no Supabase com `supabase-setup.sql` (tabela `news_posts` e policies RLS de leitura/inserção). 

### Testing
- Iniciado servidor local com `python3 -m http.server 4173` e verificado com `curl -I` que `autores.html`, `politica-editorial.html` e `index.html` responderam `200 OK`. 
- Executado script Playwright (Firefox) que carregou `autores.html` e salvou captura para inspeção visual em `artifacts/autores-editorial-page.png`. 
- Validação de carregamento das páginas e assets concluída com sucesso sem erros críticos (apenas 404 esperado para `favicon.ico` durante testes locais).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a5b0fee588332a3884ba28cc82034)